### PR TITLE
Add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# Global owner
+* @dannyfeliz @dawin09


### PR DESCRIPTION
This will auto-assign everybody (you and me 😂) as a reviewer when someone opens a PR.

This is useful for more stuff, but I only care about this feature.

Source: [code owners](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners)